### PR TITLE
Fix 0.1.4 release

### DIFF
--- a/net.hypatiaproject.Hypatia.json
+++ b/net.hypatiaproject.Hypatia.json
@@ -33,7 +33,7 @@
                 {
                     "type" : "archive",
                     "url" : "https://codeberg.org/nathandyer/Hypatia/archive/0.1.4.tar.gz",
-                    "sha256" : "a82414df59eed32038e5eb6acd7f9d4dc071014dd0e908c15d61be63ebb5423b"
+                    "sha256" : "dabe510ad793cb9d828545a7baafd7cda3ff39ceaa9434e46c817cf7bc23225d"
                 }
             ]
         }


### PR DESCRIPTION
I had forgotten to update the AppData file to list the new version, so I published a corrected release which naturally has a different hash value.